### PR TITLE
chore: add LICENSE.md with project licensing information

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,56 @@
+## Licenses
+
+The etzee ecosystem is built on open collaboration and shared engineering.
+To balance openness, attribution, and identity protection, different parts of this project are released under distinct licenses as outlined below.
+
+---
+
+#### Firmware and Protocols
+
+License: Apache License 2.0
+
+Covers:
+-	The htoyto protocol implementation
+
+You may:
+-	Use, modify, and distribute freely (including commercially)
+-	File patents while protecting contributors through explicit patent rights
+
+You must:
+-	Include copyright and license notices in redistributions
+-	Provide attribution to the original authors
+
+---
+
+#### Hardware Designs
+
+License: CERN Open Hardware License Version 2 – Strongly Reciprocal (CERN OHL-S v2)
+
+Covers:
+-	PCBs, schematics, 3D models, and connector layouts
+
+You may:
+-	Study, modify, and manufacture derived hardware
+-	Distribute modified designs under the same license
+
+You must:
+-	Release source files of modified hardware publicly
+- Attribute the original design to etzee contributors
+
+---
+
+#### Documentation and Diagrams
+
+License: Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
+
+Covers:
+-	Documentation and Markdown files
+-	Diagrams, charts, manufacturing instructions
+
+You may:
+-	Share and remix, including for commercial purposes
+-	Publish derivatives under the same license
+
+You must:
+-	Attribute etzee and its contributors
+-	Maintain the same license for derivatives


### PR DESCRIPTION
This document outlines the licenses applicable to different parts of the etzee ecosystem, including firmware, hardware designs, and documentation.